### PR TITLE
Fix missing type declaration in react-drag-drop-upload moduleFeature/fix error when importing (#1)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
 export { ReactDragDropUpload } from "./src/components/react-drag-drop-upload";
+export type * from "./src/components/react-drag-drop-upload";

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Miguel Leite <miguelleite2000leite@gmail.com>",
   "license": "MIT",
   "private": false,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Miguel Leite <miguelleite2000leite@gmail.com>",
   "license": "MIT",
   "private": false,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",

--- a/src/components/react-drag-drop-upload/drag-drop-upload.tsx
+++ b/src/components/react-drag-drop-upload/drag-drop-upload.tsx
@@ -10,7 +10,7 @@ import {
 } from "./upload-components";
 import useDragging from "../../hooks/use-dragging";
 
-interface FileUploaderProps {
+export interface FileUploaderProps {
   dragging: boolean;
   error: boolean;
   currFiles: File[] | File | null;
@@ -23,7 +23,7 @@ interface FileUploaderProps {
   disabled: boolean | undefined;
 }
 
-interface Props {
+export interface DraDropUploadProps {
   name?: string;
   messageSuccess?: string;
   messageError?: string;
@@ -49,7 +49,9 @@ interface Props {
   dropMessageStyle?: React.CSSProperties | undefined;
 }
 
-const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
+const DraDropUpload: React.FC<DraDropUploadProps> = (
+  props: DraDropUploadProps
+): JSX.Element => {
   const {
     name,
     hoverTitle,
@@ -249,4 +251,4 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
     </UploadWrapper>
   );
 };
-export default FileUploader;
+export default DraDropUpload;

--- a/src/components/react-drag-drop-upload/index.ts
+++ b/src/components/react-drag-drop-upload/index.ts
@@ -1,1 +1,3 @@
-export { default as ReactDragDropUpload } from "./file-upload";
+export { default as ReactDragDropUpload } from "./drag-drop-upload";
+export type * from "./drag-drop-upload";
+export type * from "./upload-components";


### PR DESCRIPTION
This fix adds the export of the `ReactDragDropUpload` interface in the `index.ts` file, ensuring correct generation of type declarations for the `react-drag-drop-upload` module.

**Resolved Issue**: #1